### PR TITLE
fix: add GOOGLE_OAUTH_CLIENT_ID to Cloud Run deployment

### DIFF
--- a/.github/workflows/deploy-mcp-to-cloud-run.yml
+++ b/.github/workflows/deploy-mcp-to-cloud-run.yml
@@ -34,4 +34,4 @@ jobs:
             --project ${{ secrets.GCP_PROJECT_ID }} \
             --platform managed \
             --allow-unauthenticated \
-            --set-env-vars "GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }},REGION=${{ secrets.REGION }},VERTEXAI_EMBEDDING_MODEL=${{ secrets.VERTEXAI_EMBEDDING_MODEL }},GCS_BUCKET_NAME=${{ secrets.GCS_BUCKET_NAME }},GCS_DEFAULT_BUCKET_LOCATION=${{ secrets.GCS_DEFAULT_BUCKET_LOCATION }}"
+            --set-env-vars "GCP_PROJECT_ID=${{ secrets.GCP_PROJECT_ID }},REGION=${{ secrets.REGION }},VERTEXAI_EMBEDDING_MODEL=${{ secrets.VERTEXAI_EMBEDDING_MODEL }},GCS_BUCKET_NAME=${{ secrets.GCS_BUCKET_NAME }},GCS_DEFAULT_BUCKET_LOCATION=${{ secrets.GCS_DEFAULT_BUCKET_LOCATION }},GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}"


### PR DESCRIPTION
- Add GOOGLE_OAUTH_CLIENT_ID environment variable to GitHub Actions deployment
- Required for OAuth authentication flow to work in production
- Fixes "OAuth client was not found" error during authorization

This enables the OAuth flow for Claude Desktop and MCP inspector connections to the production MCP server.

🤖 Generated with [Claude Code](https://claude.ai/code)