### PR TITLE
fix: add Firestore persistence for OAuth client registrations

### DIFF
--- a/mcp/src/routes/oauth.ts
+++ b/mcp/src/routes/oauth.ts
@@ -16,7 +16,7 @@ import {
  */
 export function configureOAuthRoutes(router: Router): void {
   // Client Registration Endpoint (Dynamic Client Registration)
-  router.post("/oauth/register", (req: Request, res: Response) => {
+  router.post("/oauth/register", async (req: Request, res: Response) => {
     const {
       client_name,
       client_uri,
@@ -45,7 +45,7 @@ export function configureOAuthRoutes(router: Router): void {
 
     try {
       // Register the client
-      const client = registerClient(
+      const client = await registerClient(
         client_name,
         client_uri,
         redirect_uris,
@@ -105,7 +105,7 @@ export function configureOAuthRoutes(router: Router): void {
   );
 
   // Authorization Endpoint
-  router.get("/auth/authorize", (req: Request, res: Response) => {
+  router.get("/auth/authorize", async (req: Request, res: Response) => {
     const { client_id, redirect_uri, response_type, state, scope } = req.query;
 
     console.log("[OAuth] Authorization request:", {
@@ -125,7 +125,7 @@ export function configureOAuthRoutes(router: Router): void {
     }
 
     // Validate client exists and redirect URI is authorized
-    const client = getRegisteredClient(client_id as string);
+    const client = await getRegisteredClient(client_id as string);
     if (!client) {
       return res.status(400).json({
         error: "invalid_client",
@@ -133,7 +133,7 @@ export function configureOAuthRoutes(router: Router): void {
       });
     }
 
-    if (!validateRedirectUri(client_id as string, redirect_uri as string)) {
+    if (!(await validateRedirectUri(client_id as string, redirect_uri as string))) {
       return res.status(400).json({
         error: "invalid_request",
         error_description: "Invalid redirect URI",
@@ -262,7 +262,7 @@ export function configureOAuthRoutes(router: Router): void {
     }
 
     // Validate client credentials
-    if (!validateClient(client_id, client_secret)) {
+    if (!(await validateClient(client_id, client_secret))) {
       return res.status(401).json({
         error: "invalid_client",
         error_description: "Invalid client credentials",

--- a/mcp/src/services/oauthSessions.ts
+++ b/mcp/src/services/oauthSessions.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "crypto";
+import { db } from "../../../services/firebaseService";
 
 interface OAuthSession {
   authorizationCode: string;
@@ -23,9 +24,11 @@ interface RegisteredClient {
   createdAt: Date;
 }
 
-// Simple in-memory storage for OAuth sessions and registered clients
+// Simple in-memory storage for OAuth sessions (keeping sessions in memory for now)
 const oauthSessions = new Map<string, OAuthSession>();
-const registeredClients = new Map<string, RegisteredClient>();
+
+// Collections for Firestore persistence
+const OAUTH_CLIENTS_COLLECTION = "oauthClients";
 
 // Cleanup interval (run every 5 minutes)
 const CLEANUP_INTERVAL = 5 * 60 * 1000;
@@ -129,14 +132,14 @@ export function validateState(state: string, expectedState: string): boolean {
 /**
  * Register a new OAuth client
  */
-export function registerClient(
+export async function registerClient(
   clientName: string,
   clientUri?: string,
   redirectUris?: string[],
   grantTypes?: string[],
   responseTypes?: string[],
   scope?: string,
-): RegisteredClient {
+): Promise<RegisteredClient> {
   const clientId = generateClientId();
   const clientSecret = generateClientSecret();
   const now = new Date();
@@ -154,27 +157,51 @@ export function registerClient(
     createdAt: now,
   };
 
-  registeredClients.set(clientId, client);
-
-  console.log(`[OAuth] Registered new client: ${clientName} (${clientId})`);
-  return client;
+  try {
+    // Save to Firestore
+    await db.collection(OAUTH_CLIENTS_COLLECTION).doc(clientId).set({
+      ...client,
+      createdAt: now,
+    });
+    
+    console.log(`[OAuth] Registered new client: ${clientName} (${clientId})`);
+    return client;
+  } catch (error) {
+    console.error(`[OAuth] Failed to register client ${clientName}:`, error);
+    throw error;
+  }
 }
 
 /**
  * Get registered client by client ID
  */
-export function getRegisteredClient(clientId: string): RegisteredClient | null {
-  return registeredClients.get(clientId) || null;
+export async function getRegisteredClient(clientId: string): Promise<RegisteredClient | null> {
+  try {
+    const doc = await db.collection(OAUTH_CLIENTS_COLLECTION).doc(clientId).get();
+    
+    if (!doc.exists) {
+      return null;
+    }
+    
+    const data = doc.data();
+    return {
+      ...data,
+      createdAt: data?.createdAt?.toDate() || new Date(),
+    } as RegisteredClient;
+  } catch (error) {
+    console.error(`[OAuth] Failed to get client ${clientId}:`, error);
+    return null;
+  }
 }
 
 /**
  * Validate client credentials
  */
-export function validateClient(
+export async function validateClient(
   clientId: string,
   clientSecret?: string,
-): boolean {
-  const client = registeredClients.get(clientId);
+): Promise<boolean> {
+  const client = await getRegisteredClient(clientId);
   if (!client) {
     return false;
   }
@@ -190,11 +217,11 @@ export function validateClient(
 /**
  * Validate redirect URI for client
  */
-export function validateRedirectUri(
+export async function validateRedirectUri(
   clientId: string,
   redirectUri: string,
-): boolean {
-  const client = registeredClients.get(clientId);
+): Promise<boolean> {
+  const client = await getRegisteredClient(clientId);
   if (!client) {
     return false;
   }


### PR DESCRIPTION
## Summary
- Fixed OAuth client registration persistence issue causing "Client not found or not registered" error
- Moved OAuth client storage from in-memory Map to Firestore for persistence across server restarts
- Updated OAuth route handlers to use async database operations

## Problem
The MCP server was storing OAuth client registrations in memory, which caused:
1. Claude registers OAuth client → stored in memory
2. Server restarts/memory clears → client registration lost  
3. Claude tries to authorize → "Client not found or not registered" error

## Solution
- **Added Firestore persistence**: Created `oauthClients` collection for persistent storage
- **Updated `registerClient()`**: Made async and saves to Firestore
- **Updated `getRegisteredClient()`**: Made async and reads from Firestore  
- **Updated OAuth routes**: Made handlers async to support database operations

## Test plan
- [x] TypeScript compilation passes
- [x] MCP server builds successfully
- [x] OAuth client registration persists across server restarts
- [ ] Test Claude integration - should resolve "Client not found" error
- [ ] Verify OAuth flow completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)