### PR TITLE
fix: add URL-encoded body parser for OAuth token endpoint

### DIFF
--- a/mcp/src/server/express.ts
+++ b/mcp/src/server/express.ts
@@ -79,8 +79,9 @@ export function createServer() {
     }),
   );
 
-  // Use body-parser middleware for JSON
+  // Use body-parser middleware for JSON and URL-encoded data
   app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
 
   // Apply IP throttling middleware
   app.use(ipThrottlingMiddleware);


### PR DESCRIPTION
The OAuth token exchange endpoint was failing because req.body was undefined. OAuth token requests use application/x-www-form-urlencoded format, but the server only had JSON body parsing enabled. Added urlencoded body parser to handle OAuth token requests properly.

🤖 Generated with [Claude Code](https://claude.ai/code)