### PR TITLE
debug: add OAuth client validation logging

### DIFF
--- a/mcp/src/routes/oauth.ts
+++ b/mcp/src/routes/oauth.ts
@@ -265,6 +265,7 @@ export function configureOAuthRoutes(router: Router): void {
 
     // Validate client credentials
     if (!(await validateClient(client_id, client_secret))) {
+      console.log("[OAuth] Client validation failed for:", client_id);
       return res.status(401).json({
         error: "invalid_client",
         error_description: "Invalid client credentials",

--- a/mcp/src/services/oauthSessions.ts
+++ b/mcp/src/services/oauthSessions.ts
@@ -209,16 +209,20 @@ export async function validateClient(
   clientId: string,
   clientSecret?: string,
 ): Promise<boolean> {
+  console.log(`[OAuth] Validating client: ${clientId}, has secret: ${!!clientSecret}`);
   const client = await getRegisteredClient(clientId);
   if (!client) {
+    console.log(`[OAuth] Client validation failed: client not found`);
     return false;
   }
 
   // If client has a secret, it must match
   if (client.clientSecret && client.clientSecret !== clientSecret) {
+    console.log(`[OAuth] Client validation failed: secret mismatch`);
     return false;
   }
 
+  console.log(`[OAuth] Client validation successful`);
   return true;
 }
 


### PR DESCRIPTION
Added detailed logging to OAuth client validation and token exchange to debug why token requests are failing with 401 errors.

🤖 Generated with [Claude Code](https://claude.ai/code)