### PR TITLE
Fix field preservation in crates_update tool

### DIFF
--- a/mcp/src/tools/crates_update.ts
+++ b/mcp/src/tools/crates_update.ts
@@ -92,6 +92,7 @@ export function registerCratesUpdateTool(server: McpServer): void {
         }
 
         // Prepare update data based on what was provided
+        // Only include fields that are explicitly provided to avoid overwriting existing values
         const updateData: Partial<Crate> = {};
 
         // Update metadata fields if provided
@@ -161,16 +162,20 @@ export function registerCratesUpdateTool(server: McpServer): void {
           updateData.searchField = searchText.toLowerCase();
 
           // Use the existing crate info but with the updated file
+          // Merge original crate data with updates to preserve all existing fields
+          const mergedCrateData = {
+            ...originalCrate,
+            ...updateData,
+            id: originalCrate.id, // Preserve the ID
+            ownerId: userId,
+            shared: originalCrate.shared, // Preserve sharing settings
+          };
+
           const crateData = await uploadCrate(
             buffer,
             actualFileName,
             actualContentType,
-            {
-              ...updateData,
-              id: originalCrate.id, // Preserve the ID
-              ownerId: userId,
-              shared: originalCrate.shared, // Preserve sharing settings
-            },
+            mergedCrateData,
           );
 
           // Log the update event


### PR DESCRIPTION
## Summary

- Fixed issue where `crates_update` was clearing existing fields when updating content
- The problem occurred when updating content - `uploadCrate` was only receiving partial update data
- Now properly merges original crate data with updates to preserve all existing fields

## Root Cause

When updating content via `crates_update`, the code was passing only the `updateData` object to `uploadCrate` instead of merging it with the original crate data. This caused fields like tags, metadata, category, etc. to be lost if they weren't explicitly provided in the update call.

## Fix Applied

- Merge original crate data with update data before calling `uploadCrate`
- Ensures all existing fields are preserved during content updates
- Only explicitly provided fields are updated, others remain unchanged

## Test Plan

- [x] Verify content updates preserve existing tags when tags aren't specified
- [x] Verify content updates preserve existing metadata when metadata isn't specified  
- [x] Verify content updates preserve existing category when category isn't specified
- [x] Verify explicit field updates still work correctly
- [x] Verify metadata-only updates continue to work (no regression)
- [x] Type checking and build process passes

🤖 Generated with [Claude Code](https://claude.ai/code)