### PR TITLE
feat: add web interface copy crate functionality

### DIFF
--- a/app/api/crates/[id]/copy/route.ts
+++ b/app/api/crates/[id]/copy/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCrateMetadata } from "@/lib/services";
+import { getCrateContent, uploadCrate } from "@/services/storageService";
+import { auth } from "@/lib/firebaseAdmin";
+
+/**
+ * API endpoint to copy a crate to the user's collection
+ * Based on the MCP crates_copy tool functionality
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+
+    // Check authentication
+    const authHeader = req.headers.get("authorization");
+    let userId = "anonymous";
+    let isAuthenticated = false;
+
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      const token = authHeader.substring(7);
+      try {
+        const decodedToken = await auth.verifyIdToken(token);
+        userId = decodedToken.uid;
+        isAuthenticated = true;
+      } catch (error) {
+        console.warn(`Invalid authentication token:`, error);
+      }
+    }
+
+    // Require authentication for this operation
+    if (!isAuthenticated || userId === "anonymous") {
+      return NextResponse.json(
+        {
+          error: "You need to be logged in to copy crates to your collection.",
+        },
+        { status: 401 },
+      );
+    }
+
+    // Get the source crate metadata
+    const sourceCrate = await getCrateMetadata(id);
+    if (!sourceCrate) {
+      return NextResponse.json({ error: "Crate not found." }, { status: 404 });
+    }
+
+    // Check if the crate is already owned by the user
+    if (sourceCrate.ownerId === userId) {
+      return NextResponse.json(
+        { error: "This crate is already in your collection." },
+        { status: 400 },
+      );
+    }
+
+    // Check if the crate is accessible to the user
+    const isPublic = sourceCrate.shared?.public === true;
+    const isAnonymous = sourceCrate.ownerId === "anonymous";
+
+    if (!isPublic && !isAnonymous) {
+      return NextResponse.json(
+        { error: "You don't have permission to copy this crate." },
+        { status: 403 },
+      );
+    }
+
+    // Get the crate content
+    const { buffer, crate } = await getCrateContent(id);
+
+    // Prepare new crate data for the copy
+    const newCrateData = {
+      title: `Copy of ${sourceCrate.title}`,
+      description: sourceCrate.description,
+      ownerId: userId,
+      category: sourceCrate.category,
+      tags: sourceCrate.tags,
+      metadata: sourceCrate.metadata,
+      shared: {
+        public: false, // Make the copy private by default
+      },
+    };
+
+    // Upload the copy with the new owner
+    const newCrate = await uploadCrate(
+      buffer,
+      sourceCrate.fileName,
+      sourceCrate.mimeType,
+      newCrateData,
+    );
+
+    return NextResponse.json({
+      success: true,
+      message: `Crate copied successfully to your collection. New crate ID: ${newCrate.id}`,
+      crate: {
+        id: newCrate.id,
+        title: newCrate.title,
+        description: newCrate.description,
+        category: newCrate.category,
+      },
+    });
+  } catch (error) {
+    console.error("Error copying crate:", error);
+    return NextResponse.json(
+      {
+        error: `Failed to copy crate: ${error instanceof Error ? error.message : "Unknown error"}`,
+      },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add "Copy to My Crates" feature to shared crate pages that provides feature parity with the existing MCP `crates_copy` tool
- Users can now copy shared crates to their collection directly from the web interface
- Includes proper authentication, access control, loading states, and user feedback

## Changes Made
- **New API Endpoint**: Created `/api/crates/[id]/copy` that mirrors MCP tool logic
- **UI Enhancement**: Added "Copy to My Crates" button to shared crate pages
- **Access Control**: Same permissions as MCP tool (public/anonymous crates only)
- **User Experience**: Loading states, success messages, error handling
- **Authentication**: Requires sign-in, shows prompt for anonymous users

## Test Plan
- [x] TypeScript compilation passes
- [x] Next.js build succeeds without errors
- [x] Code formatted with prettier
- [ ] Manual testing: Copy public crate as authenticated user
- [ ] Manual testing: Verify access denied for private crates
- [ ] Manual testing: Check sign-in prompt for anonymous users

## Technical Details
- Reuses existing `uploadCrate` and `getCrateContent` functions from storage service
- Uses Firebase Auth for authentication (same as other endpoints)
- Follows existing error handling and response patterns
- Copies are made private by default with title prefix "Copy of"

🤖 Generated with [Claude Code](https://claude.ai/code)