### PR TITLE
Fix OAuth user ID sanitization for Firestore compatibility

### DIFF
--- a/mcp/src/routes/oauth.ts
+++ b/mcp/src/routes/oauth.ts
@@ -251,8 +251,20 @@ export function configureOAuthRoutes(router: Router): void {
       });
 
       // Step 3: Create Firebase custom token with user information
-      // Format: firebase_custom_token_{timestamp}_{userId}_{email}
-      const firebaseToken = `firebase_custom_token_${Date.now()}_${userInfo.id}_${userInfo.email}`;
+      // Sanitize user ID to be Firestore-compatible (no slashes, special chars)
+      const sanitizedUserId = userInfo.id.replace(/[\/\\\.\#\$\[\]]/g, "_");
+
+      if (sanitizedUserId !== userInfo.id) {
+        console.log(
+          "[OAuth] Sanitized user ID:",
+          userInfo.id,
+          "->",
+          sanitizedUserId,
+        );
+      }
+
+      // Format: firebase_custom_token_{timestamp}_{sanitizedUserId}_{email}
+      const firebaseToken = `firebase_custom_token_${Date.now()}_${sanitizedUserId}_${userInfo.email}`;
 
       // Generate authorization code for the client
       const authorizationCode = generateAuthorizationCode();


### PR DESCRIPTION
## Summary
• Fixed Firestore document path error when OAuth user IDs contain special characters like slashes
• Sanitized OAuth user IDs to replace forbidden characters with underscores
• Added logging for the sanitization process to track when user IDs are modified

## Problem
OAuth user IDs from Google can contain forward slashes (e.g., `4/0AVMBsJj53crHxcX4K5dLuIAgs8qIwZ8Be8tKADubQQaO7PIhcKUJHWZqQS3o9lRJWlhQPA`), which Firestore interprets as collection/document path separators, causing "documentPath must point to a document" errors.

## Solution
- Sanitize OAuth user IDs by replacing special characters (`/`, `\`, `.`, `#`, `$`, `[`, `]`) with underscores
- Apply sanitization before creating Firebase custom tokens
- Log when sanitization occurs for debugging purposes

## Test plan
- [x] Test OAuth flow with user IDs containing slashes
- [x] Verify Firestore operations work with sanitized user IDs
- [x] Confirm MCP tools can access user data without path errors
- [x] Validate that email extraction still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)