### PR TITLE
fix: add OAuth user ID sanitization to authentication middleware

### DIFF
--- a/lib/apiKeyAuth.ts
+++ b/lib/apiKeyAuth.ts
@@ -118,8 +118,21 @@ export function apiKeyAuthMiddleware(
     // The token format is: firebase_custom_token_{timestamp}_{userId}_{email}
     const tokenParts = token.split("_");
     if (tokenParts.length >= 5) {
-      const userId = tokenParts[3]; // User ID is the 4th part (index 3)
+      const rawUserId = tokenParts[3]; // User ID is the 4th part (index 3)
       const email = tokenParts.slice(4).join("_"); // Email is everything after userId
+
+      // Sanitize user ID to ensure Firestore compatibility (handle both old and new tokens)
+      const userId = rawUserId.replace(/[\/\\\.\#\$\[\]]/g, "_");
+
+      if (userId !== rawUserId) {
+        console.log(
+          "[apiKeyAuthMiddleware] Sanitized OAuth user ID:",
+          rawUserId,
+          "->",
+          userId,
+        );
+      }
+
       req.user = {
         userId: userId,
         authMethod: "firebase_auth",


### PR DESCRIPTION
- Sanitize user IDs in authentication middleware to handle old tokens
- Apply same sanitization regex to ensure Firestore compatibility
- Add logging for sanitization process in middleware
- Ensures both new and existing OAuth tokens work correctly

This addresses the issue where existing OAuth tokens contain unsanitized user IDs that cause Firestore document path errors.

🤖 Generated with [Claude Code](https://claude.ai/code)