### PR TITLE
Fix Firebase custom token detection logic in authentication middleware

### DIFF
--- a/lib/apiKeyAuth.ts
+++ b/lib/apiKeyAuth.ts
@@ -129,9 +129,30 @@ export function apiKeyAuthMiddleware(
         aud: payload.aud,
         uid: payload.uid,
         hasFirebaseIss: payload.iss && payload.iss.includes("firebase"),
+        hasFirebaseAud:
+          payload.aud && payload.aud.includes("identitytoolkit.googleapis.com"),
+        isCustomToken:
+          payload.iss &&
+          payload.aud &&
+          payload.uid &&
+          (payload.iss.includes("gserviceaccount.com") ||
+            payload.iss.includes("firebase")) &&
+          payload.aud.includes("identitytoolkit.googleapis.com"),
       });
 
-      if (payload.iss && payload.iss.includes("firebase") && payload.uid) {
+      // Firebase custom tokens have:
+      // - iss: service account email (ends with @developer.gserviceaccount.com or @firebase-adminsdk-*.iam.gserviceaccount.com)
+      // - aud: https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit
+      // - uid: user ID
+      const isFirebaseCustomToken =
+        payload.iss &&
+        payload.aud &&
+        payload.uid &&
+        (payload.iss.includes("gserviceaccount.com") ||
+          payload.iss.includes("firebase")) &&
+        payload.aud.includes("identitytoolkit.googleapis.com");
+
+      if (isFirebaseCustomToken) {
         // This looks like a Firebase custom token, extract the uid directly
         req.user = {
           userId: payload.uid,


### PR DESCRIPTION
## Summary
Fixes the Firebase custom token detection logic to properly recognize OAuth-generated custom tokens based on production logs showing the actual token format.

## Problem Identified
Production debugging revealed that Firebase custom tokens have a different issuer format than expected:

**Actual token format**:
```json
{
  "iss": "568125764461-compute@developer.gserviceaccount.com",
  "aud": "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit", 
  "uid": "8gvs3jid1LTc4ewr73MegjQFop52"
}
```

**Previous detection logic**: Expected `iss` to contain "firebase"  
**Reality**: Firebase custom tokens use service account email as issuer

## Root Cause
The authentication middleware was checking if the issuer contained "firebase":
```typescript
if (payload.iss && payload.iss.includes("firebase") && payload.uid) {
```

But Firebase custom tokens actually use the service account email format:
- `@developer.gserviceaccount.com` (Compute Engine default service account)
- `@firebase-adminsdk-*.iam.gserviceaccount.com` (Firebase Admin SDK service account)

## Solution

### Updated Detection Logic
```typescript
const isFirebaseCustomToken = payload.iss && payload.aud && payload.uid &&
  (payload.iss.includes("gserviceaccount.com") || payload.iss.includes("firebase")) &&
  payload.aud.includes("identitytoolkit.googleapis.com");
```

### Comprehensive Validation
Now checks for:
- **Issuer**: Contains `gserviceaccount.com` or `firebase`
- **Audience**: Contains `identitytoolkit.googleapis.com` 
- **User ID**: Present in `uid` field

### Enhanced Debugging
Added detailed logging to track validation logic:
```typescript
console.log("[apiKeyAuthMiddleware] JWT payload:", {
  iss: payload.iss,
  aud: payload.aud,
  uid: payload.uid,
  hasFirebaseIss: payload.iss && payload.iss.includes("firebase"),
  hasFirebaseAud: payload.aud && payload.aud.includes("identitytoolkit.googleapis.com"),
  isCustomToken: /* validation result */
});
```

## Expected Result
After this fix, OAuth authentication should work properly:
1. Firebase custom tokens will be recognized correctly
2. User ID `8gvs3jid1LTc4ewr73MegjQFop52` will be extracted  
3. User email will be fetched and used as crate owner
4. No more "API key not found in database" errors

## Test Plan
- [x] TypeScript compilation passes
- [x] MCP server builds successfully
- [x] Code formatting applied
- [ ] Deploy and test OAuth authentication
- [ ] Verify custom token detection succeeds
- [ ] Confirm user emails appear as crate owners

This fix is based on actual production logs and should resolve the OAuth authentication issues.

🤖 Generated with [Claude Code](https://claude.ai/code)