### PR TITLE
fix: Fix MCP call counter tracking and improve UI consistency

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -239,7 +239,7 @@ const AdminDashboardPage: React.FC = () => {
                   {stats.totalMcpCalls?.toLocaleString() ?? "N/A"}
                 </p>
                 <div className="mt-2 text-xs text-gray-600">
-                  Lifetime MCP API calls
+                  Lifetime MCP calls
                 </div>
               </div>
               <div className="bg-gradient-to-r from-orange-50 to-orange-100 rounded-lg p-5 border-l-4 border-orange-500">
@@ -302,9 +302,7 @@ const AdminDashboardPage: React.FC = () => {
               </h3>
               <div className="flex flex-col md:flex-row md:justify-between">
                 <div>
-                  <div className="text-sm text-gray-600">
-                    Total MCP API Calls
-                  </div>
+                  <div className="text-sm text-gray-600">Total MCP Calls</div>
                   <div className="text-2xl font-bold">
                     {stats.totalMcpCalls?.toLocaleString() ?? "N/A"}
                   </div>

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -59,6 +59,12 @@ const faqItems: FAQItem[] = [
     answer:
       "Content uploaded by authenticated users is stored permanently and never expires (until you delete it). However, download links generated for sharing expire after 24 hours for security reasons. The actual content remains accessible through the public sharing link.",
   },
+  {
+    id: "claude-ai-connection",
+    question: "How do I connect MCPH to Claude AI?",
+    answer:
+      "To connect MCPH to Claude AI, go to https://claude.ai/settings/connectors and add a custom connector. Set the name to 'MCPH' and use the MCP endpoint URL: https://api.mcph.io/mcp. You'll need your MCPH API key which you can generate from your account settings.",
+  },
 ];
 
 export default function FAQPage() {

--- a/components/home/APIQuotaInfo.tsx
+++ b/components/home/APIQuotaInfo.tsx
@@ -51,7 +51,7 @@ const APIQuotaInfo: React.FC<APIQuotaInfoProps> = ({
         <div className="text-gray-500 text-sm">Loading quota...</div>
       ) : userQuota ? (
         <div className="text-sm text-gray-700">
-          Remaining MCP calls this month:{" "}
+          MCP calls this month:{" "}
           <span
             className={
               userQuota.remaining === 0
@@ -59,7 +59,7 @@ const APIQuotaInfo: React.FC<APIQuotaInfoProps> = ({
                 : "font-semibold"
             }
           >
-            {userQuota.remaining}
+            {1000 - userQuota.remaining}
           </span>
           <span className="ml-2 text-gray-400">/ 1000</span>
         </div>

--- a/components/home/UsagePills.tsx
+++ b/components/home/UsagePills.tsx
@@ -67,12 +67,12 @@ const UsageModal: React.FC<UsageModalProps> = ({
         </div>
 
         <div className="space-y-4">
-          {/* API Calls */}
+          {/* MCP Calls */}
           {userQuota && (
             <div>
               <div className="flex justify-between text-sm mb-1">
-                <span>API Calls</span>
-                <span>{userQuota.remaining}/1000</span>
+                <span>MCP Calls</span>
+                <span>{1000 - userQuota.remaining}/1000</span>
               </div>
               <div className="w-full bg-gray-200 rounded-full h-2">
                 <div
@@ -233,7 +233,7 @@ const UsagePills: React.FC<UsagePillsProps> = ({
           </button>
         )}
 
-        {/* API Calls Pill */}
+        {/* MCP Calls Pill */}
         {userQuota && (
           <button
             onClick={() => setIsModalOpen(true)}
@@ -244,7 +244,7 @@ const UsagePills: React.FC<UsagePillsProps> = ({
             }`}
           >
             <FaPhone className="inline mr-1" />
-            API Calls {userQuota.remaining}/1000
+            MCP Calls {1000 - userQuota.remaining}/1000
           </button>
         )}
 

--- a/mcp/src/config/server.ts
+++ b/mcp/src/config/server.ts
@@ -58,8 +58,8 @@ export function createMcpServer(req?: AuthenticatedRequest): McpServer {
   });
 
   // --- WRAP TOOL REGISTRATION FOR USAGE TRACKING ---
-  const originalTool = server.tool;
-  server.tool = function (...args: any[]) {
+  const originalRegisterTool = server.registerTool;
+  server.registerTool = function (...args: any[]) {
     const toolName = args[0];
     let handler: any;
     if (args.length === 3) {
@@ -67,7 +67,7 @@ export function createMcpServer(req?: AuthenticatedRequest): McpServer {
     } else if (args.length >= 4) {
       handler = args[args.length - 1];
     }
-    if (!handler) return (originalTool as any).apply(server, args);
+    if (!handler) return (originalRegisterTool as any).apply(server, args);
     const wrappedHandler = async (toolArgs: any, ...rest: any[]) => {
       try {
         if (req?.user && req.user.userId) {
@@ -95,7 +95,7 @@ export function createMcpServer(req?: AuthenticatedRequest): McpServer {
     } else {
       args[args.length - 1] = wrappedHandler;
     }
-    return (originalTool as any).apply(server, args);
+    return (originalRegisterTool as any).apply(server, args);
   };
 
   return server;


### PR DESCRIPTION
## Summary
- Fixed MCP tool usage tracking by wrapping server.registerTool instead of server.tool
- Updated UI labels from "API Calls" to "MCP Calls" for consistency
- Changed counter display to show used calls (0-based) instead of remaining calls
- Added FAQ entry for connecting MCPH to Claude AI

## Technical Changes
- **Fixed tool usage tracking**: Updated `mcp/src/config/server.ts` to wrap `server.registerTool` instead of `server.tool`, fixing the root cause of non-updating MCP call counters
- **Updated counter display logic**: Modified `UsagePills` and `APIQuotaInfo` components to show used calls (e.g., "5/1000") instead of remaining calls for consistency with other metrics
- **Improved UI consistency**: Updated all labels from "API Calls" to "MCP Calls" across the application
- **Enhanced FAQ**: Added instructions for connecting MCPH to Claude AI via custom connectors

## Test Plan
- [x] MCP tools now properly increment usage counter in `userUsage` Firestore collection
- [x] Crate page displays MCP calls starting from 0 in used/total format (e.g., "5/1000")
- [x] UI labels consistently show "MCP Calls" instead of "API Calls"
- [x] FAQ includes step-by-step Claude AI connection instructions with proper URL
- [x] Admin dashboard labels updated for consistency

🤖 Generated with [Claude Code](https://claude.ai/code)